### PR TITLE
test(android): Ensure the "release" app has the Javascript bundled

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -74,9 +74,7 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     entryFile: "example/index.js",
-    nodeExecutableAndArgs: ["echo", "'Skipping bundling"],
-    root: "../../../",
-    bundleInRelease: false
+    root: "../../../"
 ]
 
 apply from: "../../../node_modules/react-native/react.gradle"


### PR DESCRIPTION
The issue with the Android tests on CircleCI is that it tests with the release version of the app but the Javascript was not bundled within it. This PR re-enables the Javascript bundling so the app can run correctly without a Metro packager running.