### PR TITLE
[FIX][iOS] All mediaTypes return order

### DIFF
--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -61,7 +61,8 @@ RCT_ENUM_CONVERTER(PHAssetCollectionSubtype, (@{
                   "'videos' or 'all'.", mediaType);
     }
     // This case includes the "all" mediatype
-    return nil;
+    PHFetchOptions *const options = [PHFetchOptions new];
+    return options;
   }
 }
 


### PR DESCRIPTION
Fixes [#27](https://github.com/react-native-community/react-native-cameraroll/issues/27) (iOS: Order when request assetType:All is incorrect)