### PR TITLE
chore(CI): Fix iOS release build bundling so tests pass

### DIFF
--- a/example/ios/CameraRollExample.xcodeproj/project.pbxproj
+++ b/example/ios/CameraRollExample.xcodeproj/project.pbxproj
@@ -938,7 +938,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$CONFIGURATION\" == \"Debug\" ]; then\n    echo \"Debug Configuration\"\n    export NODE_BINARY=node\n    ../../node_modules/react-native/scripts/react-native-xcode.sh\nelse\n    echo \"Tests: Release Configuration\"\n    RESOURCE_PATH=$SRCROOT/../../.tmp\n    FILENAME_IN_BUNDLE=main.jsbundle\n    BUILD_APP_DIR=${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app\n    cp $RESOURCE_PATH/ios-bundle.js $BUILD_APP_DIR/$FILENAME_IN_BUNDLE\n    echo \"Tests: Copied main.jsbundle from ./.tmp\"\nfi\n";
+			shellScript = "export NODE_BINARY=node\n../../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
When the repo was first set up it assumed that the JS was bundled and persisted in the first CircleCI job. With the change to the CircleCI Orb, this was no longer the case and the bundling needs to happen when the iOS app is built.

To do this, I have reverted the "Bundle React Native code and images" build phase to just run the standard `node_modules/react-native/scripts/react-native-xcode.sh` script for all configurations.