### PR TITLE
Add description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Bartol Karuza <bartol.k@gmail.com>",
   "homepage": "https://github.com/react-native-community/react-native-cameraroll#readme",
   "version": "1.0.3",
-  "description": "",
+  "description": "React Native Camera Roll for iOS & Android",
   "main": "./js/CameraRoll.js",
   "types": "./typings/CameraRoll.d.ts",
   "scripts": {


### PR DESCRIPTION
The description is needed, else `pod install` complains about an invalid summary field in the podspec