### PR TITLE
chore(ci) add publish step on master commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,14 @@ jobs:
       - run:
           name: iOS JavaScript Bundle
           command: yarn run test:detox:ios:bundle:release
+  publish:
+    executor: rn/linux_js
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Publish to NPM
+          command: yarn ci:publish
 
 workflows:
   test:
@@ -43,18 +51,18 @@ workflows:
       - analyze:
           requires:
             - checkout_code
-      # - rn/android_build:
-      #     name: android_debug_build
-      #     project_path: "example/android"
-      #     build_type: debug
-      #     requires:
-      #       - analyze
-      # - rn/android_build:
-      #     name: android_release_build
-      #     project_path: "example/android"
-      #     build_type: release
-      #     requires:
-      #       - analyze
+      - rn/android_build:
+          name: android_debug_build
+          project_path: "example/android"
+          build_type: debug
+          requires:
+            - analyze
+      - rn/android_build:
+          name: android_release_build
+          project_path: "example/android"
+          build_type: release
+          requires:
+            - analyze
       # - rn/android_test:
       #     logcat_grep: "com.camerarollexample"
       #     detox_configuration: "android.emu.release"
@@ -69,3 +77,10 @@ workflows:
       #     detox_configuration: "ios.sim.release"
       #     requires:
       #       - analyze
+      - publish:
+          requires:
+            - checkout_code
+            - analyze
+          filters:
+            branches:
+              only: master

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,15 @@
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
+    "@semantic-release/github",
+    [
+      "@semantic-release/git",
+      {
+        "assets": "package.json",
+        "message": "chore(release): ${nextRelease.version} [skip ci] \n\n${nextRelease.notes}"
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
Turns Android release/debug builds on commit back on (smoke test, e2e is still off)
Adds a publish step to CircleCI on master commits