### PR TITLE
Use the MimeType reported by the media Cursor instead of trying to guess the mime type from uri

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -43,7 +43,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.net.URLConnection;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.List;
@@ -366,7 +365,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       WritableMap edge = new WritableNativeMap();
       WritableMap node = new WritableNativeMap();
       boolean imageInfoSuccess =
-          putImageInfo(resolver, media, node, idIndex, widthIndex, heightIndex, dataIndex);
+          putImageInfo(resolver, media, node, idIndex, widthIndex, heightIndex, dataIndex, mimeTypeIndex);
       if (imageInfoSuccess) {
         putBasicNodeInfo(media, node, mimeTypeIndex, groupNameIndex, dateTakenIndex);
         putLocationInfo(media, node, longitudeIndex, latitudeIndex);
@@ -401,14 +400,15 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       int idIndex,
       int widthIndex,
       int heightIndex,
-      int dataIndex) {
+      int dataIndex,
+      int mimeTypeIndex) {
     WritableMap image = new WritableNativeMap();
     Uri photoUri = Uri.parse("file://" + media.getString(dataIndex));
     image.putString("uri", photoUri.toString());
     float width = media.getInt(widthIndex);
     float height = media.getInt(heightIndex);
 
-    String mimeType = URLConnection.guessContentTypeFromName(photoUri.toString());
+    String mimeType = media.getString(mimeTypeIndex);
 
     if (mimeType != null
         && mimeType.startsWith("video")) {


### PR DESCRIPTION
This prevents the crash when the device contains images with a `#`.

This fixes https://github.com/facebook/react-native/issues/24468.

The guessing of the content type was introduced in https://github.com/react-native-community/react-native-cameraroll/commit/da20713a64858401bfaf0067b6659905f165a764#diff-7f48a66bcd0a56ced1913161061c6e3bR434

@kesha-antonov is there a specific reason why you opted to make use of guessing the mimetype from the uri instead of using the value reported by the media Cursor?