### PR TITLE
Forced default groupType all fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ build/
 local.properties
 *.iml
 
+**/.settings
+**/.classpath
+**/.project
+
 # BUCK
 buck-out/
 \.buckd/

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -216,9 +216,6 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     ReadableArray mimeTypes = params.hasKey("mimeTypes")
         ? params.getArray("mimeTypes")
         : null;
-    if (params.hasKey("groupTypes")) {
-      throw new JSApplicationIllegalArgumentException("groupTypes is not supported on Android");
-    }
 
     new GetMediaTask(
           getReactApplicationContext(),


### PR DESCRIPTION
This PR tries to balance the intention of throwing the exception when groupType is supplied to an Android app running Cameraroll and the fact that now a default is supplied which causes #56 .
fixes #56