### PR TITLE
Fix anchors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ On Android permission is required to read the external storage. Add below line t
 
 ### Methods
 
-* [`saveToCameraRoll`](README.md#savetocameraroll)
-* [`getPhotos`](README.md#getphotos)
+* [`saveToCameraRoll`](#savetocameraroll)
+* [`getPhotos`](#getphotos)
 
 ---
 


### PR DESCRIPTION
# Overview
Currently all anchors in `README.md` cause address change. E.g. `saveToCameraRoll` link in [Methods section](https://github.com/react-native-community/react-native-cameraroll#methods) should lead to
```
https://github.com/react-native-community/react-native-cameraroll#savetocameraroll
```
but leads to
```
https://github.com/react-native-community/react-native-cameraroll/blob/master/README.md#savetocameraroll
```

This PR fixes that.
# Test Plan
Try clicking on the same link in [Methods section with the fix](https://github.com/lebedev/react-native-cameraroll/tree/patch-1#methods).