### PR TITLE
Add filename back into the image properties iOS and Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Returns a Promise which when resolved will be of the following shape:
     * `group_name`: {string}
     * `image`: {object} : An object with the following shape:
       * `uri`: {string}
+      * `filename`: {string}
       * `height`: {number}
       * `width`: {number}
       * `isStored`: {boolean}

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -401,7 +401,10 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       int mimeTypeIndex) {
     WritableMap image = new WritableNativeMap();
     Uri photoUri = Uri.parse("file://" + media.getString(dataIndex));
+    File file = new File(media.getString(dataIndex));
+    String strFileName = file.getName();
     image.putString("uri", photoUri.toString());
+    image.putString("filename", strFileName);
     float width = media.getInt(widthIndex);
     float height = media.getInt(heightIndex);
 

--- a/ios/RNCAssetsLibraryRequestHandler.m
+++ b/ios/RNCAssetsLibraryRequestHandler.m
@@ -15,13 +15,14 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 
 #import <React/RCTBridge.h>
+#import <React/RCTNetworking.h>
 #import <React/RCTUtils.h>
 
 @implementation RNCAssetsLibraryRequestHandler
 
 RCT_EXPORT_MODULE()
 
-#pragma mark - RCTURLRequestHandler
+#pragma mark - RNCURLRequestHandler
 
 - (BOOL)canHandleRequest:(NSURLRequest *)request
 {
@@ -30,7 +31,8 @@ RCT_EXPORT_MODULE()
   }
 
   return [request.URL.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame
-    || [request.URL.scheme caseInsensitiveCompare:@"ph"] == NSOrderedSame;
+    || [request.URL.scheme caseInsensitiveCompare:@"ph"] == NSOrderedSame
+    || [request.URL.scheme caseInsensitiveCompare:RCTNetworkingPHUploadHackScheme] == NSOrderedSame;
 }
 
 - (id)sendRequest:(NSURLRequest *)request
@@ -40,8 +42,14 @@ RCT_EXPORT_MODULE()
   void (^cancellationBlock)(void) = ^{
     atomic_store(&cancelled, YES);
   };
+
+  NSURL *requestURL = request.URL;
+  BOOL isPHUpload = [requestURL.scheme caseInsensitiveCompare:RCTNetworkingPHUploadHackScheme] == NSOrderedSame;
+  if (isPHUpload) {
+    requestURL = [NSURL URLWithString:[@"ph" stringByAppendingString:[requestURL.absoluteString substringFromIndex:RCTNetworkingPHUploadHackScheme.length]]];
+  }
   
-  if (!request.URL) {
+  if (!requestURL) {
     NSString *const msg = [NSString stringWithFormat:@"Cannot send request without URL"];
     [delegate URLRequest:cancellationBlock didCompleteWithError:RCTErrorWithMessage(msg)];
     return cancellationBlock;
@@ -49,23 +57,23 @@ RCT_EXPORT_MODULE()
   
   PHFetchResult<PHAsset *> *fetchResult;
  
-  if ([request.URL.scheme caseInsensitiveCompare:@"ph"] == NSOrderedSame) {
+  if ([requestURL.scheme caseInsensitiveCompare:@"ph"] == NSOrderedSame) {
     // Fetch assets using PHAsset localIdentifier (recommended)
-    NSString *const localIdentifier = [request.URL.absoluteString substringFromIndex:@"ph://".length];
+    NSString *const localIdentifier = [requestURL.absoluteString substringFromIndex:@"ph://".length];
     fetchResult = [PHAsset fetchAssetsWithLocalIdentifiers:@[localIdentifier] options:nil];
-  } else if ([request.URL.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame) {
+  } else if ([requestURL.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame) {
     // This is the older, deprecated way of fetching assets from assets-library
     // using the "assets-library://" protocol
-    fetchResult = [PHAsset fetchAssetsWithALAssetURLs:@[request.URL] options:nil];
+    fetchResult = [PHAsset fetchAssetsWithALAssetURLs:@[requestURL] options:nil];
   } else {
-    NSString *const msg = [NSString stringWithFormat:@"Cannot send request with unknown protocol: %@", request.URL];
+    NSString *const msg = [NSString stringWithFormat:@"Cannot send request with unknown protocol: %@", requestURL];
     [delegate URLRequest:cancellationBlock didCompleteWithError:RCTErrorWithMessage(msg)];
     return cancellationBlock;
   }
   
   if (![fetchResult firstObject]) {
     NSString *errorMessage = [NSString stringWithFormat:@"Failed to load asset"
-                              " at URL %@ with no error message.", request.URL];
+                              " at URL %@ with no error message.", requestURL];
     NSError *error = RCTErrorWithMessage(errorMessage);
     [delegate URLRequest:cancellationBlock didCompleteWithError:error];
     return cancellationBlock;
@@ -77,37 +85,70 @@ RCT_EXPORT_MODULE()
 
   PHAsset *const _Nonnull asset = [fetchResult firstObject];
 
-  // By default, allow downloading images from iCloud
-  PHImageRequestOptions *const requestOptions = [PHImageRequestOptions new];
-  requestOptions.networkAccessAllowed = YES;
-  
-  [[PHImageManager defaultManager] requestImageDataForAsset:asset
-                                                    options:requestOptions
-                                              resultHandler:^(NSData * _Nullable imageData,
-                                                              NSString * _Nullable dataUTI,
-                                                              UIImageOrientation orientation,
-                                                              NSDictionary * _Nullable info) {
-    NSError *const error = [info objectForKey:PHImageErrorKey];
-    if (error) {
+  // When we're uploading a video, provide the full data but in any other case,
+  // provide only the thumbnail of the video.
+  if (asset.mediaType == PHAssetMediaTypeVideo && isPHUpload) {
+    PHVideoRequestOptions *const requestOptions = [PHVideoRequestOptions new];
+    requestOptions.networkAccessAllowed = YES;
+    [[PHImageManager defaultManager] requestAVAssetForVideo:asset options:requestOptions resultHandler:^(AVAsset * _Nullable avAsset, AVAudioMix * _Nullable audioMix, NSDictionary * _Nullable info) {
+      NSError *error = [info objectForKey:PHImageErrorKey];
+      if (error) {
+        [delegate URLRequest:cancellationBlock didCompleteWithError:error];
+        return;
+      }
+
+      if (![avAsset isKindOfClass:[AVURLAsset class]]) {
+        error = [NSError errorWithDomain:RCTErrorDomain code:0 userInfo:
+        @{
+          NSLocalizedDescriptionKey: @"Unable to load AVURLAsset",
+          }];
+        [delegate URLRequest:cancellationBlock didCompleteWithError:error];
+        return;
+      }
+
+      NSData *data = [NSData dataWithContentsOfURL:((AVURLAsset *)avAsset).URL
+                                           options:(NSDataReadingOptions)0
+                                             error:&error];
+      if (data) {
+        NSURLResponse *const response = [[NSURLResponse alloc] initWithURL:request.URL MIMEType:nil expectedContentLength:data.length textEncodingName:nil];
+        [delegate URLRequest:cancellationBlock didReceiveResponse:response];
+        [delegate URLRequest:cancellationBlock didReceiveData:data];
+      }
       [delegate URLRequest:cancellationBlock didCompleteWithError:error];
-      return;
-    }
+    }];
+  } else {
+    // By default, allow downloading images from iCloud
+    PHImageRequestOptions *const requestOptions = [PHImageRequestOptions new];
+    requestOptions.networkAccessAllowed = YES;
 
-    NSInteger const length = [imageData length];
-    CFStringRef const dataUTIStringRef = (__bridge CFStringRef _Nonnull)(dataUTI);
-    CFStringRef const mimeType = UTTypeCopyPreferredTagWithClass(dataUTIStringRef, kUTTagClassMIMEType);
+    [[PHImageManager defaultManager] requestImageDataForAsset:asset
+                                                      options:requestOptions
+                                                resultHandler:^(NSData * _Nullable imageData,
+                                                                NSString * _Nullable dataUTI,
+                                                                UIImageOrientation orientation,
+                                                                NSDictionary * _Nullable info) {
+      NSError *const error = [info objectForKey:PHImageErrorKey];
+      if (error) {
+        [delegate URLRequest:cancellationBlock didCompleteWithError:error];
+        return;
+      }
 
-    NSURLResponse *const response = [[NSURLResponse alloc] initWithURL:request.URL
-                                                              MIMEType:(__bridge NSString *)(mimeType)
-                                                 expectedContentLength:length
-                                                      textEncodingName:nil];
-    if(mimeType) CFRelease(mimeType);
-    
-    [delegate URLRequest:cancellationBlock didReceiveResponse:response];
-    
-    [delegate URLRequest:cancellationBlock didReceiveData:imageData];
-    [delegate URLRequest:cancellationBlock didCompleteWithError:nil];
-  }];
+      NSInteger const length = [imageData length];
+      CFStringRef const dataUTIStringRef = (__bridge CFStringRef _Nonnull)(dataUTI);
+      CFStringRef const mimeType = UTTypeCopyPreferredTagWithClass(dataUTIStringRef, kUTTagClassMIMEType);
+
+      NSURLResponse *const response = [[NSURLResponse alloc] initWithURL:request.URL
+                                                                MIMEType:(__bridge NSString *)(mimeType)
+                                                   expectedContentLength:length
+                                                        textEncodingName:nil];
+      CFRelease(mimeType);
+
+      [delegate URLRequest:cancellationBlock didReceiveResponse:response];
+
+      [delegate URLRequest:cancellationBlock didReceiveData:imageData];
+      [delegate URLRequest:cancellationBlock didCompleteWithError:nil];
+    }];
+  }
   
   return cancellationBlock;
 }

--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -230,13 +230,13 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
       }
 
       // Get underlying resources of an asset - this includes files as well as details about edited PHAssets
-      if ([mimeTypes count] > 0) {
-        NSArray<PHAssetResource *> *const assetResources = [PHAssetResource assetResourcesForAsset:asset];
-        if (![assetResources firstObject]) {
-          return;
-        }
+      NSArray<PHAssetResource *> *const assetResources = [PHAssetResource assetResourcesForAsset:asset];
+      if (![assetResources firstObject]) {
+        return;
+      }
+      PHAssetResource *const _Nonnull resource = [assetResources firstObject];
 
-        PHAssetResource *const _Nonnull resource = [assetResources firstObject];
+      if ([mimeTypes count] > 0) {
         CFStringRef const uti = (__bridge CFStringRef _Nonnull)(resource.uniformTypeIdentifier);
         NSString *const mimeType = (NSString *)CFBridgingRelease(UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType));
 
@@ -272,6 +272,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
                                                   ? @"audio"
                                                   : @"unknown")));
       CLLocation *const loc = asset.location;
+      NSString *const origFilename = resource.originalFilename;
 
       // A note on isStored: in the previous code that used ALAssets, isStored
       // was always set to YES, probably because iCloud-synced images were never returned (?).
@@ -286,6 +287,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
           @"group_name": currentCollectionName,
           @"image": @{
               @"uri": uri,
+              @"filename": origFilename,
               @"height": @([asset pixelHeight]),
               @"width": @([asset pixelWidth]),
               @"isStored": @YES, // this field doesn't seem to exist on android


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR restores the filename back to the image properties.  This works in both iOS and Android, as well as updated docs.  The propterty was still in the typescript definition.

This really is a subset/duplication of https://github.com/react-native-community/react-native-cameraroll/pull/30 except for being limited only to filename, but also including docs and android implementation.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

![Screen Shot 2019-05-31 at 3 14 32 PM](https://user-images.githubusercontent.com/296661/58732493-4e742880-83b7-11e9-9485-933b3791c81b.png)
![Screenshot_1559333808](https://user-images.githubusercontent.com/296661/58732535-6d72ba80-83b7-11e9-8bbb-16bdd0326105.png)


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
