### PR TITLE
Convert PHAsset to JPEG for uploading

### DIFF
--- a/ios/RNCAssetsLibraryRequestHandler.m
+++ b/ios/RNCAssetsLibraryRequestHandler.m
@@ -118,6 +118,38 @@ RCT_EXPORT_MODULE()
       }
       [delegate URLRequest:cancellationBlock didCompleteWithError:error];
     }];
+  } else if (isPHUpload) {
+    // By default, allow downloading images from iCloud
+    PHImageRequestOptions *const requestOptions = [PHImageRequestOptions new];
+    requestOptions.networkAccessAllowed = YES;
+      requestOptions.deliveryMode = PHImageRequestOptionsDeliveryModeHighQualityFormat;
+
+      CGSize const targetSize = CGSizeMake((CGFloat)asset.pixelWidth, (CGFloat)asset.pixelHeight);
+      [[PHImageManager defaultManager] requestImageForAsset:asset
+                                                 targetSize:targetSize
+                                                contentMode:PHImageContentModeDefault
+                                                    options:requestOptions
+                                              resultHandler:^(UIImage * _Nullable image,
+                                                              NSDictionary * _Nullable info) {
+      NSError *const error = [info objectForKey:PHImageErrorKey];
+      if (error) {
+        [delegate URLRequest:cancellationBlock didCompleteWithError:error];
+        return;
+      }
+      
+      NSData *const imageData = UIImageJPEGRepresentation(image, 1.0);
+      NSInteger const length = [imageData length];
+
+      NSURLResponse *const response = [[NSURLResponse alloc] initWithURL:request.URL
+                                                                MIMEType:@"image/jpeg"
+                                                   expectedContentLength:length
+                                                        textEncodingName:nil];
+
+      [delegate URLRequest:cancellationBlock didReceiveResponse:response];
+
+      [delegate URLRequest:cancellationBlock didReceiveData:imageData];
+      [delegate URLRequest:cancellationBlock didCompleteWithError:nil];
+    }];
   } else {
     // By default, allow downloading images from iCloud
     PHImageRequestOptions *const requestOptions = [PHImageRequestOptions new];


### PR DESCRIPTION
# Summary

Uploading images from the Camera Roll used to be in JPEG format when assets were retrieved with `assets-library` protocol, but now they are returned as HEIC if stored that way. This breaks all apps relying on images being JPEGs.

These changes use the `isPHupload` flag already used to ensure that a video is correctly uploaded (not only the thumbnail), and applies conversion only when uploading.

## Test Plan

I made and tested this patch on a view allowing to choose photos from the camera roll and then uploading them as `FormData`.

### What's required for testing (prerequisites)?

An iPhone or iPad configured to take pictures in HEIC format. (default on latest iOS versions)

### What are the steps to reproduce (after prerequisites)?

1. Take a photo with the camera app
2. Get that photo's uri from the camera roll
3. Append it to a FormData
4. Check the `mime/type` => `image/heic`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    N/A     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device
- [ ] I have tested this on a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
