### PR TITLE
Remove unrecognised UTF8 tag from xcworkspace file

### DIFF
--- a/ios/RNCCameraroll.xcworkspace/contents.xcworkspacedata
+++ b/ios/RNCCameraroll.xcworkspace/contents.xcworkspacedata
@@ -1,4 +1,3 @@
-// !$*UTF8*$!
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">


### PR DESCRIPTION
# Summary

When trying to open the workspace file with XCode I kept getting an error that XCode couldn't open the file. This fixes that error.

## Test Plan

Open file in XCode.

### What's required for testing (prerequisites)?

A mac with XCode.

### What are the steps to reproduce (after prerequisites)?

Double click the xcworkspace file. Apply changes and you'll be able to open the file.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md` (Still can't find this file, where is it?)
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
