### PR TITLE
Fix warning for deprecated RCTBridge interface for RCTImageLoader

### DIFF
--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -176,7 +176,7 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
       inputURI = request.URL;
       saveWithOptions();
     } else {
-      [self.bridge.imageLoader loadImageWithURLRequest:request callback:^(NSError *error, UIImage *image) {
+      [[self->_bridge moduleForClass:[RCTImageLoader class]] loadImageWithURLRequest:request callback:^(NSError *error, UIImage *image) {
         if (error) {
           reject(kErrorUnableToLoad, nil, error);
           return;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Fixes #86

This library is using a class that got deprecated in React Native `0.61.0`. (https://github.com/facebook/react-native/blob/0.61-stable/React/CoreModules/RCTImageLoader.h)

This PR makes it so we're now using the recommended implementation.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Save an image to the camera roll and make sure no yellow box appears and that the image is successfully saved.

### What are the steps to reproduce (after prerequisites)?
In the current version of the library, save a photo to the camera roll and observe the yellow box.

<img width="365" alt="Screen Shot 2019-09-25 at 2 13 12 PM" src="https://user-images.githubusercontent.com/7979579/65637090-34cfa000-dfa9-11e9-9b5b-42ea287059c6.png">

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    N/A     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
