### PR TITLE
[Android] Use DCIM direcotry for saveToCameraRoll

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -125,14 +125,8 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       File source = new File(mUri.getPath());
       FileChannel input = null, output = null;
       try {
-        File environment;
-        if ("mov".equals(mOptions.getString("type"))) {
-          environment = Environment.getExternalStoragePublicDirectory(
-                  Environment.DIRECTORY_MOVIES);
-        } else {
-          environment = Environment.getExternalStoragePublicDirectory(
-                  Environment.DIRECTORY_PICTURES);
-        }
+        File environment = Environment.getExternalStoragePublicDirectory(
+          Environment.DIRECTORY_DCIM);
         File exportDir;
         if (!"".equals(mOptions.getString("album"))) {
           exportDir = new File(environment, mOptions.getString("album"));


### PR DESCRIPTION
# Summary

Use DCIM dir for saveToCameraRoll. We noticed an increase in `External media storage directory not available` errors for our app. We noticed that the react-native-cameraroll in the current react-native project is using the DCIM directory, and was changed from the MOVIES and PICTURES dir quite a while ago. 

See here: https://github.com/facebook/react-native/blame/15ecb60d6deb96fcb7b0ef70faccd10594ededa3/ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java#L136

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- N/A I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- N/A I updated the typed files (TS and Flow)
- N/A I added a sample use of the API in the example project (`example/App.js`)
