### PR TITLE
Fix #97 Android 10 screenshot sorted incorrectly

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -326,7 +326,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
             PROJECTION,
             selection.toString(),
             selectionArgs.toArray(new String[selectionArgs.size()]),
-            Images.Media.DATE_TAKEN + " DESC, " + Images.Media.DATE_MODIFIED + " DESC LIMIT " +
+            Images.Media.DATE_ADDED + " DESC, " + Images.Media.DATE_MODIFIED + " DESC LIMIT " +
                 (mFirst + 1)); // set LIMIT to first + 1 so that we know how to populate page_info
         if (media == null) {
           mPromise.reject(ERROR_UNABLE_TO_LOAD, "Could not get media");


### PR DESCRIPTION
Fix outlined in #97 

# Summary

Screenshots taken in Android 10 are no longer tagged with DATE_TAKEN but only DATE_ADDED. This causes screenshots taken in Android 10 to appear at the bottom of a potentially very long list.

## Test Plan

I have no solid test plan. I've tested it locally.

### What's required for testing (prerequisites)?

A photo library with at least 10 items, to clearly see how screenshots are shown last.

### What are the steps to reproduce (after prerequisites)?

See issue

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
