### PR TITLE
Fix build error in RNCCameraRollManager.m

### DIFF
--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -17,7 +17,7 @@
 
 #import <React/RCTBridge.h>
 #import <React/RCTConvert.h>
-#import <React/RCTImageLoader.h>
+#import <React/RCTImageLoaderProtocol.h>
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
 
@@ -176,7 +176,7 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
       inputURI = request.URL;
       saveWithOptions();
     } else {
-      [[self->_bridge moduleForClass:[RCTImageLoader class]] loadImageWithURLRequest:request callback:^(NSError *error, UIImage *image) {
+      [[self.bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES] loadImageWithURLRequest:request callback:^(NSError *error, UIImage *image) {
         if (error) {
           reject(kErrorUnableToLoad, nil, error);
           return;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
After upgrading to 1.3.0 that includes #87, my builds started to fail on the step to link react-native-cameraroll with the following message:
`Undefined symbol: _OBJC_Class_$_RCTImageLoader`.
<img width="1276" alt="Screen Shot 2019-11-12 at 1 24 31 PM" src="https://user-images.githubusercontent.com/9336864/68701321-88e01500-0554-11ea-8451-9e600ca88ccb.png">

I'm not sure what @tomtargosz's environment is like that allowed this to work, but it does not seem to work in 0.61.x with autolinked (cocoapods) dependencies. It looks like the recommendation made in that file by the react-native team is incorrect. I'm also not 100% confident this will work with RN < 0.60. I suspect the way `react-native-svg` fixed this may be backwards compatible - see [this commit](https://github.com/react-native-community/react-native-svg/commit/5452144468c2fbc157db7383e00ebd72bdad6af0) and [this one that specifically notes backwards-compatibility](https://github.com/react-native-community/react-native-svg/commit/3c22c9757277145a18a509c3aee36dddc6a610e7)

The correct way to fix this, which I see in [react-native-image-crop-picker](https://github.com/ivpusic/react-native-image-crop-picker/blob/master/ios/src/ImageCropPicker.m#L394) and in [several](https://github.com/facebook/react-native/blob/master/Libraries/Image/RCTImageEditingManager.mm#L60) [internal](https://github.com/facebook/react-native/blob/master/Libraries/Image/RCTImageView.m#L324) [react files](https://github.com/facebook/react-native/blob/master/Libraries/Image/RCTImageViewManager.m#L57), is to use `[self.bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES]`.
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I made these changes in my local copy of the cocoapods and was able to compile.


### What's required for testing (prerequisites)?
A react-native app on RN 0.61.x that includes this package as an autolinked dependency via cocoapods. 

### What are the steps to reproduce (after prerequisites)?
Try to build. It fails (for me - I haven't tried to repro with a fresh create-react-native-app but I don't see why it would work with a fresh app).

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] ~I added the documentation in `README.md`~
- [x] ~I mentioned this change in `CHANGELOG.md`~
- [x] ~I updated the typed files (TS and Flow)~
- [x] ~I added a sample use of the API in the example project (`example/App.js`)~
