### PR TITLE
Manually obtain location metadata using ExifInterface

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -504,7 +504,6 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
         float[] latLng = new float[2];
         boolean hasLatLong = exif.getLatLong(latLng);
         if (hasLatLong) {
-          Log.d("SYED", "putImageInfo: " + latLng[0]);
           double longitude = latLng[1];
           double latitude = latLng[0];
           if (longitude > 0 || latitude > 0) {
@@ -515,7 +514,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
           }
         }
     }catch (IOException e){
-      Log.d("SYED", "putLocationInfo: "+e);
+      FLog.e(ReactConstants.TAG, "Could read the metadata", e);
     }
     // double longitude = media.getDouble(longitudeIndex);
     // double latitude = media.getDouble(latitudeIndex);

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -510,9 +510,9 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
           location.putDouble("latitude", latitude);
           node.putMap("location", location);
         }
-    }catch (IOException e){
-      FLog.e(ReactConstants.TAG, "Could not read the metadata", e);
-    }
+      } catch (IOException e) {
+        FLog.e(ReactConstants.TAG, "Could not read the metadata", e);
+      }
   }
 
   /**

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -21,6 +21,7 @@ import android.os.Environment;
 import android.provider.MediaStore;
 import android.provider.MediaStore.Images;
 import android.text.TextUtils;
+import android.media.ExifInterface;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.GuardedAsyncTask;

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -511,7 +511,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
           node.putMap("location", location);
         }
     }catch (IOException e){
-      FLog.e(ReactConstants.TAG, "Could read the metadata", e);
+      FLog.e(ReactConstants.TAG, "Could not read the metadata", e);
     }
   }
 

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -386,7 +386,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
           putImageInfo(resolver, media, node, idIndex, widthIndex, heightIndex, dataIndex, mimeTypeIndex);
       if (imageInfoSuccess) {
         putBasicNodeInfo(media, node, mimeTypeIndex, groupNameIndex, dateTakenIndex);
-        putLocationInfo(media, node, longitudeIndex, latitudeIndex);
+        putLocationInfo(media, node, longitudeIndex, latitudeIndex, dataIndex);
 
         edge.putMap("node", node);
         edges.pushMap(edge);
@@ -496,15 +496,34 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       Cursor media,
       WritableMap node,
       int longitudeIndex,
-      int latitudeIndex) {
-    double longitude = media.getDouble(longitudeIndex);
-    double latitude = media.getDouble(latitudeIndex);
-    if (longitude > 0 || latitude > 0) {
-      WritableMap location = new WritableNativeMap();
-      location.putDouble("longitude", longitude);
-      location.putDouble("latitude", latitude);
-      node.putMap("location", location);
+      int latitudeIndex,
+      int dataIndex) {
+      try {
+        final ExifInterface exif = new ExifInterface(media.getString(dataIndex));
+        float[] latLng = new float[2];
+        boolean hasLatLong = exif.getLatLong(latLng);
+        if (hasLatLong) {
+          Log.d("SYED", "putImageInfo: " + latLng[0]);
+          double longitude = latLng[1];
+          double latitude = latLng[0];
+          if (longitude > 0 || latitude > 0) {
+            WritableMap location = new WritableNativeMap();
+            location.putDouble("longitude", longitude);
+            location.putDouble("latitude", latitude);
+            node.putMap("location", location);
+          }
+        }
+    }catch (IOException e){
+      Log.d("SYED", "putLocationInfo: "+e);
     }
+    // double longitude = media.getDouble(longitudeIndex);
+    // double latitude = media.getDouble(latitudeIndex);
+    // if (longitude > 0 || latitude > 0) {
+    //   WritableMap location = new WritableNativeMap();
+    //   location.putDouble("longitude", longitude);
+    //   location.putDouble("latitude", latitude);
+    //   node.putMap("location", location);
+    // }
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary


LATITUDE and LONGITUDE are deprecated in API level 29, image coordinates are null. we manually obtained location metadata using ExifInterface

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
