### PR TITLE
changes to fix IOS MetaData

### DIFF
--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -172,8 +172,8 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
   };
 
   void (^loadBlock)(void) = ^void() {
-      inputURI = request.URL;
-      saveWithOptions();
+    inputURI = request.URL;
+    saveWithOptions();
   };
 
   requestPhotoLibraryAccess(reject, loadBlock);

--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -123,7 +123,7 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
       if ([options[@"type"] isEqualToString:@"video"]) {
         assetRequest = [PHAssetChangeRequest creationRequestForAssetFromVideoAtFileURL:inputURI];
       } else {
-        assetRequest = [PHAssetChangeRequest creationRequestForAssetFromImage:inputImage];
+        assetRequest = [PHAssetChangeRequest creationRequestForAssetFromImageAtFileURL:inputURI];
       }
       placeholder = [assetRequest placeholderForCreatedAsset];
       if (![options[@"album"] isEqualToString:@""]) {
@@ -172,20 +172,8 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
   };
 
   void (^loadBlock)(void) = ^void() {
-    if ([options[@"type"] isEqualToString:@"video"]) {
       inputURI = request.URL;
       saveWithOptions();
-    } else {
-      [[self.bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES] loadImageWithURLRequest:request callback:^(NSError *error, UIImage *image) {
-        if (error) {
-          reject(kErrorUnableToLoad, nil, error);
-          return;
-        }
-
-        inputImage = image;
-        saveWithOptions();
-      }];
-    }
   };
 
   requestPhotoLibraryAccess(reject, loadBlock);


### PR DESCRIPTION
Pr of changes listed in https://github.com/react-native-community/react-native-cameraroll/issues/125

Allows for ios to save metadata and images


| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

- [x ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)