### PR TITLE
Support filter media items between dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Returns a Promise with photo identifier objects from the local camera roll of th
   * `Videos`
   * `Photos` // default
 * `mimeTypes` : {Array} : Filter by mimetype (e.g. image/jpeg).
+* `fromTime` : {timestamp} : Filter from date added.
+* `toTime` : {timestamp} : Filter to date added.
 
 Returns a Promise which when resolved will be of the following shape:
 

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -328,13 +328,9 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
         selection.append(" AND " + Images.Media.DATE_TAKEN + " > ?");
         selectionArgs.add(mFromTime + "");
       }
-      long toTime = mToTime;
-      if (!TextUtils.isEmpty(mAfter)) {
-        toTime = Long.parseLong(mAfter);
-      }
-      if (toTime > 0) {
-        selection.append(" AND " + SELECTION_DATE_TAKEN);
-        selectionArgs.add(toTime + "");
+      if (mToTime > 0) {
+        selection.append(" AND " + Images.Media.DATE_TAKEN + " <= ?");
+        selectionArgs.add(mToTime + "");
       }
       
       WritableMap response = new WritableNativeMap();

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -234,6 +234,8 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     String after = params.hasKey("after") ? params.getString("after") : null;
     String groupName = params.hasKey("groupName") ? params.getString("groupName") : null;
     String assetType = params.hasKey("assetType") ? params.getString("assetType") : ASSET_TYPE_PHOTOS;
+    int fromTime = params.hasKey("fromTime") ? params.getInt("fromTime") : 0;
+    int toTime = params.hasKey("toTime") ? params.getInt("toTime") : 0;
     ReadableArray mimeTypes = params.hasKey("mimeTypes")
         ? params.getArray("mimeTypes")
         : null;
@@ -245,6 +247,8 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
           groupName,
           mimeTypes,
           assetType,
+          fromTime,
+          toTime,
           promise)
           .executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
   }
@@ -257,6 +261,8 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     private final @Nullable ReadableArray mMimeTypes;
     private final Promise mPromise;
     private final String mAssetType;
+    private final int mFromTime;
+    private final int mToTime;
 
     private GetMediaTask(
         ReactContext context,
@@ -265,6 +271,8 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
         @Nullable String groupName,
         @Nullable ReadableArray mimeTypes,
         String assetType,
+        int fromTime,
+        int toTime,
         Promise promise) {
       super(context);
       mContext = context;
@@ -274,6 +282,8 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       mMimeTypes = mimeTypes;
       mPromise = promise;
       mAssetType = assetType;
+      mFromTime = fromTime;
+      mToTime = toTime;
     }
 
     @Override
@@ -316,6 +326,15 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
           selectionArgs.add(mMimeTypes.getString(i));
         }
         selection.replace(selection.length() - 1, selection.length(), ")");
+      }
+
+      if (mFromTime > 0) {
+        selection.append(" AND " + Images.Media.DATE_ADDED + " > ?" );
+        selectionArgs.add(mFromTime + "");
+      }
+      if (mToTime > 0) {
+        selection.append(" AND " + Images.Media.DATE_ADDED + " < ?" );
+        selectionArgs.add(mToTime + "");
       }
       WritableMap response = new WritableNativeMap();
       ContentResolver resolver = mContext.getContentResolver();

--- a/ios/RNCCameraRollManager.h
+++ b/ios/RNCCameraRollManager.h
@@ -12,7 +12,9 @@
 
 @interface RCTConvert (PHFetchOptions)
 
-+ (PHFetchOptions *)PHFetchOptionsFromMediaType:(NSString *)mediaType;
++ (PHFetchOptions *)PHFetchOptionsFromMediaType:(NSString *)mediaType
+                                       fromTime:(NSUInteger)fromTime
+                                         toTime:(NSUInteger)toTime;
 
 @end
 

--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -53,10 +53,10 @@ RCT_ENUM_CONVERTER(PHAssetCollectionSubtype, (@{
   
   if ([lowercase isEqualToString:@"photos"]) {
     [format addObject:@"mediaType = %d"];
-    [arguments addObject:[NSNumber numberWithInteger:PHAssetMediaTypeImage]];
+    [arguments addObject:@(PHAssetMediaTypeImage)];
   } else if ([lowercase isEqualToString:@"videos"]) {
     [format addObject:@"mediaType = %d"];
-    [arguments addObject:[NSNumber numberWithInteger:PHAssetMediaTypeVideo]];
+    [arguments addObject:@(PHAssetMediaTypeVideo)];
   } else {
     if (![lowercase isEqualToString:@"all"]) {
       RCTLogError(@"Invalid filter option: '%@'. Expected one of 'photos',"

--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -77,7 +77,9 @@ RCT_ENUM_CONVERTER(PHAssetCollectionSubtype, (@{
   
   // This case includes the "all" mediatype
   PHFetchOptions *const options = [PHFetchOptions new];
-  options.predicate = [NSPredicate predicateWithFormat:[format componentsJoinedByString:@" AND "] argumentArray:arguments];
+  if ([format count] > 0) {
+    options.predicate = [NSPredicate predicateWithFormat:[format componentsJoinedByString:@" AND "] argumentArray:arguments];
+  }
   return options;
 }
 

--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -225,6 +225,8 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
   NSString *const groupName = [RCTConvert NSString:params[@"groupName"]];
   NSString *const groupTypes = [[RCTConvert NSString:params[@"groupTypes"]] lowercaseString];
   NSString *const mediaType = [RCTConvert NSString:params[@"assetType"]];
+  NSUInteger const fromTime = [RCTConvert NSInteger:params[@"fromTime"]];
+  NSUInteger const toTime = [RCTConvert NSInteger:params[@"toTime"]];
   NSArray<NSString *> *const mimeTypes = [RCTConvert NSStringArray:params[@"mimeTypes"]];
   
   // If groupTypes is "all", we want to fetch the SmartAlbum "all photos". Otherwise, all
@@ -236,6 +238,18 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
   
   // Predicate for fetching assets within a collection
   PHFetchOptions *const assetFetchOptions = [RCTConvert PHFetchOptionsFromMediaType:mediaType];
+  NSString* predicateFormat = assetFetchOptions.predicate.predicateFormat;
+  if (fromTime > 0) {
+    NSDate* fromDate = [NSDate dateWithTimeIntervalSince1970:fromTime/1000];
+    NSPredicate* predicate = [NSPredicate predicateWithFormat:@"creationDate > %@", fromDate];
+    predicateFormat = [NSString stringWithFormat:@"%@ AND %@", predicateFormat, predicate.predicateFormat];
+  }
+  if (toTime > 0) {
+    NSDate* toDate = [NSDate dateWithTimeIntervalSince1970:toTime/1000];
+    NSPredicate* predicate = [NSPredicate predicateWithFormat:@"creationDate < %@", toDate];
+    predicateFormat = [NSString stringWithFormat:@"%@ AND %@", predicateFormat, predicate.predicateFormat];
+  }
+  assetFetchOptions.predicate = [NSPredicate predicateWithFormat:predicateFormat];
   assetFetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:NO]];
   
   BOOL __block foundAfter = NO;

--- a/typings/CameraRoll.d.ts
+++ b/typings/CameraRoll.d.ts
@@ -26,6 +26,8 @@ declare namespace CameraRoll {
     groupName?: string;
     assetType?: AssetType;
     mimeTypes?: Array<string>;
+    fromTime?: number;
+    toTime?: number;
   }
 
   interface PhotoIdentifier {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
This PR is a replacement of #120 that I closed accidentally. So I am going to copy the description below.

Add `fromTime` and `toTime` to `getPhotos` to get media items in between
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
Manual test on my device
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
