### PR TITLE
Fix getPhotos crash if there is a quote in an album name

### DIFF
--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -276,7 +276,8 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
   PHFetchOptions *const collectionFetchOptions = [PHFetchOptions new];
   collectionFetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"endDate" ascending:NO]];
   if (groupName != nil) {
-    collectionFetchOptions.predicate = [NSPredicate predicateWithFormat:[NSString stringWithFormat:@"localizedTitle == '%@'", groupName]];
+    collectionFetchOptions.predicate = [NSPredicate predicateWithFormat:@"localizedTitle = %@", groupName];
+
   }
   
   BOOL __block stopCollections_;


### PR DESCRIPTION
# Summary

This is a fix for cases when a user has albums with `'` in their names.

![Simulator Screen Shot - iPhone 11 - 2020-03-23 at 12 50 44](https://user-images.githubusercontent.com/15157181/77314058-3fbf7f00-6d05-11ea-98c8-fa835d700168.png)

### What are the steps to reproduce (after prerequisites)?
1. Create an album on iOS device with `'` in its' name, for example `Men's Health`.
2. Try to use a `getPhotos` method.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)

![Simulator Screen Shot - iPhone 11 - 2020-03-23 at 12 49 42](https://user-images.githubusercontent.com/15157181/77314158-667db580-6d05-11ea-8006-2638a4a1458a.png)