### PR TITLE
fix: rollback getExceptionHandler change

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -115,7 +115,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     private final ReadableMap mOptions;
 
     public SaveToCameraRoll(ReactContext context, Uri uri, ReadableMap options, Promise promise) {
-      super(context.getExceptionHandler());
+      super(context);
       mContext = context;
       mUri = uri;
       mPromise = promise;
@@ -274,7 +274,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
         long fromTime,
         long toTime,
         Promise promise) {
-      super(context.getExceptionHandler());
+      super(context);
       mContext = context;
       mFirst = first;
       mAfter = after;
@@ -612,7 +612,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     private final Promise mPromise;
 
     public DeletePhotos(ReactContext context, ReadableArray uris, Promise promise) {
-      super(context.getExceptionHandler());
+      super(context);
       mContext = context;
       mUris = uris;
       mPromise = promise;


### PR DESCRIPTION
REVERT: fix: Update deprecated functions (#149)

reverted to fix build issues on older React Native versions (deprecation warnings are a smaller problem)