### PR TITLE
Fixed reference to git repository in Podspec file

### DIFF
--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -123,7 +123,6 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
   // URLs, `data:` URIs, etc. Video URLs are passed directly through for now; it may be nice to support
   // more ways of loading videos in the future.
   __block NSURL *inputURI = nil;
-  __block UIImage *inputImage = nil;
   __block PHFetchResult *photosAsset;
   __block PHAssetCollection *collection;
   __block PHObjectPlaceholder *placeholder;

--- a/ios/RNCCameraroll.podspec
+++ b/ios/RNCCameraroll.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNCCameraroll.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/react-native-community/react-native-cameraroll.git", :tag => "master" }
   s.source_files  = "RNCCameraroll/**/*.{h,m}"
   s.requires_arc = true
 

--- a/ios/RNCCameraroll.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/RNCCameraroll.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
# Summary

Changed the url to the git repository of the project in Podspec. Installing the pod dependency was not warking with the wrong url.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |