### PR TITLE
Improve get photos logic per Jared Sumner's solution

### DIFF
--- a/ios/RNCCameraRollManager.h
+++ b/ios/RNCCameraRollManager.h
@@ -13,8 +13,7 @@
 @interface RCTConvert (PHFetchOptions)
 
 + (PHFetchOptions *)PHFetchOptionsFromMediaType:(NSString *)mediaType
-                                       fromTime:(NSUInteger)fromTime
-                                         toTime:(NSUInteger)toTime;
+                                        subType:(PHAssetMediaSubtype)subType;
 
 @end
 

--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -17,6 +17,7 @@
 
 #import <React/RCTBridge.h>
 #import <React/RCTConvert.h>
+#import <React/RCTImageLoader.h>
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
 
@@ -39,46 +40,61 @@ RCT_ENUM_CONVERTER(PHAssetCollectionSubtype, (@{
 
 @end
 
+@implementation RCTConvert (PHAssetMediaSubtype)
+
+RCT_ENUM_CONVERTER(PHAssetMediaSubtype, (@{
+   @"none": @(PHAssetMediaSubtypeNone),
+   @"panorama": @(PHAssetMediaSubtypePhotoPanorama),
+   @"hdr": @(PHAssetMediaSubtypePhotoHDR),
+   @"screenshot": @(PHAssetMediaSubtypePhotoScreenshot),
+   @"live": @(PHAssetMediaSubtypePhotoLive),
+   @"video-streamed": @(PHAssetMediaSubtypeVideoStreamed),
+   @"video-highfps": @(PHAssetMediaSubtypeVideoHighFrameRate),
+   @"timelapse": @(PHAssetMediaSubtypeVideoTimelapse),
+   @"portrait": @(PHAssetMediaSubtypePhotoDepthEffect),
+}), PHAssetMediaSubtypeNone, integerValue)
+
+@end
+
+
 @implementation RCTConvert (PHFetchOptions)
 
-+ (PHFetchOptions *)PHFetchOptionsFromMediaType:(NSString *)mediaType
-                                       fromTime:(NSUInteger)fromTime
-                                         toTime:(NSUInteger)toTime
++ (PHFetchOptions *)PHFetchOptionsFromMediaType:(NSString *)mediaType subType:(PHAssetMediaSubtype)subType
 {
   // This is not exhaustive in terms of supported media type predicates; more can be added in the future
   NSString *const lowercase = [mediaType lowercaseString];
-  NSMutableArray *format = [NSMutableArray new];
-  NSMutableArray *arguments = [NSMutableArray new];
-  
+
+  NSPredicate * subTypePredicate = nil;
+
+  if (subType != PHAssetMediaSubtypeNone) {
+    subTypePredicate = [NSPredicate predicateWithFormat:@"(mediaSubtype & %d) != 0", subType];
+  }
+
+  NSPredicate *mediaTypePredicate = nil;
+
+  PHFetchOptions *const options = [PHFetchOptions new];
+
   if ([lowercase isEqualToString:@"photos"]) {
-    [format addObject:@"mediaType = %d"];
-    [arguments addObject:@(PHAssetMediaTypeImage)];
+    mediaTypePredicate = [NSPredicate predicateWithFormat:@"mediaType = %d", PHAssetMediaTypeImage];
   } else if ([lowercase isEqualToString:@"videos"]) {
-    [format addObject:@"mediaType = %d"];
-    [arguments addObject:@(PHAssetMediaTypeVideo)];
+    mediaTypePredicate = [NSPredicate predicateWithFormat:@"mediaType = %d", PHAssetMediaTypeVideo];
   } else {
     if (![lowercase isEqualToString:@"all"]) {
       RCTLogError(@"Invalid filter option: '%@'. Expected one of 'photos',"
                   "'videos' or 'all'.", mediaType);
+
+      return options;
     }
   }
-  
-  if (fromTime > 0) {
-    NSDate* fromDate = [NSDate dateWithTimeIntervalSince1970:fromTime/1000];
-    [format addObject:@"creationDate > %@"];
-    [arguments addObject:fromDate];
+
+  if (subTypePredicate != nil && mediaTypePredicate != nil) {
+    options.predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[mediaTypePredicate, subTypePredicate]];
+  } else if (mediaTypePredicate != nil) {
+    options.predicate = mediaTypePredicate;
+  } else if (subTypePredicate != nil) {
+    options.predicate = subTypePredicate;
   }
-  if (toTime > 0) {
-    NSDate* toDate = [NSDate dateWithTimeIntervalSince1970:toTime/1000];
-    [format addObject:@"creationDate < %@"];
-    [arguments addObject:toDate];
-  }
-  
-  // This case includes the "all" mediatype
-  PHFetchOptions *const options = [PHFetchOptions new];
-  if ([format count] > 0) {
-    options.predicate = [NSPredicate predicateWithFormat:[format componentsJoinedByString:@" AND "] argumentArray:arguments];
-  }
+
   return options;
 }
 
@@ -123,6 +139,7 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
   // URLs, `data:` URIs, etc. Video URLs are passed directly through for now; it may be nice to support
   // more ways of loading videos in the future.
   __block NSURL *inputURI = nil;
+  __block UIImage *inputImage = nil;
   __block PHFetchResult *photosAsset;
   __block PHAssetCollection *collection;
   __block PHObjectPlaceholder *placeholder;
@@ -138,7 +155,7 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
       if ([options[@"type"] isEqualToString:@"video"]) {
         assetRequest = [PHAssetChangeRequest creationRequestForAssetFromVideoAtFileURL:inputURI];
       } else {
-        assetRequest = [PHAssetChangeRequest creationRequestForAssetFromImageAtFileURL:inputURI];
+        assetRequest = [PHAssetChangeRequest creationRequestForAssetFromImage:inputImage];
       }
       placeholder = [assetRequest placeholderForCreatedAsset];
       if (![options[@"album"] isEqualToString:@""]) {
@@ -157,7 +174,7 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
   };
   void (^saveWithOptions)(void) = ^void() {
     if (![options[@"album"] isEqualToString:@""]) {
-  
+
       PHFetchOptions *fetchOptions = [[PHFetchOptions alloc] init];
       fetchOptions.predicate = [NSPredicate predicateWithFormat:@"title = %@", options[@"album"] ];
       collection = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum
@@ -187,33 +204,23 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
   };
 
   void (^loadBlock)(void) = ^void() {
-    inputURI = request.URL;
-    saveWithOptions();
+    if ([options[@"type"] isEqualToString:@"video"]) {
+      inputURI = request.URL;
+      saveWithOptions();
+    } else {
+      [self.bridge.imageLoader loadImageWithURLRequest:request callback:^(NSError *error, UIImage *image) {
+        if (error) {
+          reject(kErrorUnableToLoad, nil, error);
+          return;
+        }
+
+        inputImage = image;
+        saveWithOptions();
+      }];
+    }
   };
 
   requestPhotoLibraryAccess(reject, loadBlock);
-}
-
-RCT_EXPORT_METHOD(getAlbums:(NSDictionary *)params
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
-{
-  NSString *const mediaType = [params objectForKey:@"assetType"] ? [RCTConvert NSString:params[@"assetType"]] : @"All";
-  PHFetchOptions* options = [[PHFetchOptions alloc] init];
-  PHFetchResult<PHAssetCollection *> *const assetCollectionFetchResult = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum subtype:PHAssetCollectionSubtypeAny options:options];
-  NSMutableArray * result = [NSMutableArray new];
-  [assetCollectionFetchResult enumerateObjectsUsingBlock:^(PHAssetCollection * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-    PHFetchOptions *const assetFetchOptions = [RCTConvert PHFetchOptionsFromMediaType:mediaType fromTime:0 toTime:0];
-    // Enumerate assets within the collection
-    PHFetchResult<PHAsset *> *const assetsFetchResult = [PHAsset fetchAssetsInAssetCollection:obj options:assetFetchOptions];
-    if (assetsFetchResult.count > 0) {
-      [result addObject:@{
-        @"title": [obj localizedTitle],
-        @"count": @(assetsFetchResult.count)
-      }];
-    }
-  }];
-  resolve(result);
 }
 
 static void RCTResolvePromise(RCTPromiseResolveBlock resolve,
@@ -249,35 +256,37 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
   NSString *const afterCursor = [RCTConvert NSString:params[@"after"]];
   NSString *const groupName = [RCTConvert NSString:params[@"groupName"]];
   NSString *const groupTypes = [[RCTConvert NSString:params[@"groupTypes"]] lowercaseString];
+  NSString *const mediaSubtypeStrings = [[RCTConvert NSString:params[@"mediaSubtypes"]] lowercaseString];
   NSString *const mediaType = [RCTConvert NSString:params[@"assetType"]];
-  NSUInteger const fromTime = [RCTConvert NSInteger:params[@"fromTime"]];
-  NSUInteger const toTime = [RCTConvert NSInteger:params[@"toTime"]];
   NSArray<NSString *> *const mimeTypes = [RCTConvert NSStringArray:params[@"mimeTypes"]];
-  
+
   // If groupTypes is "all", we want to fetch the SmartAlbum "all photos". Otherwise, all
   // other groupTypes values require the "album" collection type.
   PHAssetCollectionType const collectionType = ([groupTypes isEqualToString:@"all"]
                                                 ? PHAssetCollectionTypeSmartAlbum
                                                 : PHAssetCollectionTypeAlbum);
   PHAssetCollectionSubtype const collectionSubtype = [RCTConvert PHAssetCollectionSubtype:groupTypes];
-  
+
+ PHAssetMediaSubtype const mediaSubtypes = [RCTConvert PHAssetMediaSubtype:mediaSubtypeStrings];
+
   // Predicate for fetching assets within a collection
-  PHFetchOptions *const assetFetchOptions = [RCTConvert PHFetchOptionsFromMediaType:mediaType fromTime:fromTime toTime:toTime];
+  PHFetchOptions *const assetFetchOptions = [RCTConvert PHFetchOptionsFromMediaType:mediaType subType:mediaSubtypes];
   assetFetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:NO]];
-  
+
   BOOL __block foundAfter = NO;
   BOOL __block hasNextPage = NO;
   BOOL __block resolvedPromise = NO;
   NSMutableArray<NSDictionary<NSString *, id> *> *assets = [NSMutableArray new];
-  
+
   // Filter collection name ("group")
   PHFetchOptions *const collectionFetchOptions = [PHFetchOptions new];
   collectionFetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"endDate" ascending:NO]];
   if (groupName != nil) {
-    collectionFetchOptions.predicate = [NSPredicate predicateWithFormat:@"localizedTitle = %@", groupName];
-
+    collectionFetchOptions.predicate = [NSPredicate predicateWithFormat:[NSString stringWithFormat:@"localizedTitle == '%@'", groupName]];
   }
-  
+
+
+
   BOOL __block stopCollections_;
   NSString __block *currentCollectionName;
 
@@ -291,29 +300,28 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
         return; // skip until we get to the first one
       }
 
-      // Get underlying resources of an asset - this includes files as well as details about edited PHAssets
-      NSArray<PHAssetResource *> *const assetResources = [PHAssetResource assetResourcesForAsset:asset];
-      if (![assetResources firstObject]) {
-        return;
-      }
-      PHAssetResource *const _Nonnull resource = [assetResources firstObject];
-
-      if ([mimeTypes count] > 0) {
-        CFStringRef const uti = (__bridge CFStringRef _Nonnull)(resource.uniformTypeIdentifier);
-        NSString *const mimeType = (NSString *)CFBridgingRelease(UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType));
-
-        BOOL __block mimeTypeFound = NO;
-        [mimeTypes enumerateObjectsUsingBlock:^(NSString * _Nonnull mimeTypeFilter, NSUInteger idx, BOOL * _Nonnull stop) {
-          if ([mimeType isEqualToString:mimeTypeFilter]) {
-            mimeTypeFound = YES;
-            *stop = YES;
-          }
-        }];
-
-        if (!mimeTypeFound) {
+       if (mimeTypes.count > 0) {
+         // Get underlying resources of an asset - this includes files as well as details about edited PHAssets
+        NSArray<PHAssetResource *> *const assetResources = [PHAssetResource assetResourcesForAsset:asset];
+        if (![assetResources firstObject]) {
           return;
         }
+        PHAssetResource *const _Nonnull resource = [assetResources firstObject];
+
+       BOOL __block mimeTypeFound = NO;
+       [mimeTypes enumerateObjectsUsingBlock:^(NSString * _Nonnull mimeTypeFilter, NSUInteger idx, BOOL * _Nonnull stop) {
+         if ([mimeType isEqualToString:mimeTypeFilter]) {
+           mimeTypeFound = YES;
+           *stop = YES;
+         }
+       }];
+
+       if (!mimeTypeFound) {
+         return;
+       }
+       
       }
+
 
       // If we've accumulated enough results to resolve a single promise
       if (first == assets.count) {
@@ -334,7 +342,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
                                                   ? @"audio"
                                                   : @"unknown")));
       CLLocation *const loc = asset.location;
-      NSString *const origFilename = resource.originalFilename;
+      NSString *const origFilename = [asset valueForKey:@"filename"];
 
       // A note on isStored: in the previous code that used ALAssets, isStored
       // was always set to YES, probably because iCloud-synced images were never returned (?).
@@ -395,17 +403,12 @@ RCT_EXPORT_METHOD(deletePhotos:(NSArray<NSString *>*)assets
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {
-  NSMutableArray *convertedAssets = [NSMutableArray array];
-  
-  for (NSString *asset in assets) {
-    [convertedAssets addObject: [asset stringByReplacingOccurrencesOfString:@"ph://" withString:@""]];
-  }
-
+  NSArray<NSURL *> *assets_ = [RCTConvert NSURLArray:assets];
   [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
-      PHFetchResult<PHAsset *> *fetched =
-        [PHAsset fetchAssetsWithLocalIdentifiers:convertedAssets options:nil];
-      [PHAssetChangeRequest deleteAssets:fetched];
-    }
+    PHFetchResult<PHAsset *> *fetched =
+    [PHAsset fetchAssetsWithALAssetURLs:assets_ options:nil];
+    [PHAssetChangeRequest deleteAssets:fetched];
+  }
   completionHandler:^(BOOL success, NSError *error) {
     if (success == YES) {
       resolve(@(success));

--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -26,16 +26,16 @@
 @implementation RCTConvert (PHAssetCollectionSubtype)
 
 RCT_ENUM_CONVERTER(PHAssetCollectionSubtype, (@{
-   @"album": @(PHAssetCollectionSubtypeAny),
-   @"all": @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
-   @"event": @(PHAssetCollectionSubtypeAlbumSyncedEvent),
-   @"faces": @(PHAssetCollectionSubtypeAlbumSyncedFaces),
-   @"library": @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
-   @"photo-stream": @(PHAssetCollectionSubtypeAlbumMyPhotoStream), // incorrect, but legacy
-   @"photostream": @(PHAssetCollectionSubtypeAlbumMyPhotoStream),
-   @"saved-photos": @(PHAssetCollectionSubtypeAny), // incorrect, but legacy correspondence in PHAssetCollectionSubtype
-   @"savedphotos": @(PHAssetCollectionSubtypeAny), // This was ALAssetsGroupSavedPhotos, seems to have no direct correspondence in PHAssetCollectionSubtype
-}), PHAssetCollectionSubtypeAny, integerValue)
+  @"album": @(PHAssetCollectionSubtypeAny),
+  @"all": @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
+  @"event": @(PHAssetCollectionSubtypeAlbumSyncedEvent),
+  @"faces": @(PHAssetCollectionSubtypeAlbumSyncedFaces),
+  @"library": @(PHAssetCollectionSubtypeSmartAlbumUserLibrary),
+  @"photo-stream": @(PHAssetCollectionSubtypeAlbumMyPhotoStream), // incorrect, but legacy
+  @"photostream": @(PHAssetCollectionSubtypeAlbumMyPhotoStream),
+  @"saved-photos": @(PHAssetCollectionSubtypeAny), // incorrect, but legacy correspondence in PHAssetCollectionSubtype
+  @"savedphotos": @(PHAssetCollectionSubtypeAny), // This was ALAssetsGroupSavedPhotos, seems to have no direct correspondence in PHAssetCollectionSubtype
+                                              }), PHAssetCollectionSubtypeAny, integerValue)
 
 
 @end
@@ -43,16 +43,16 @@ RCT_ENUM_CONVERTER(PHAssetCollectionSubtype, (@{
 @implementation RCTConvert (PHAssetMediaSubtype)
 
 RCT_ENUM_CONVERTER(PHAssetMediaSubtype, (@{
-   @"none": @(PHAssetMediaSubtypeNone),
-   @"panorama": @(PHAssetMediaSubtypePhotoPanorama),
-   @"hdr": @(PHAssetMediaSubtypePhotoHDR),
-   @"screenshot": @(PHAssetMediaSubtypePhotoScreenshot),
-   @"live": @(PHAssetMediaSubtypePhotoLive),
-   @"video-streamed": @(PHAssetMediaSubtypeVideoStreamed),
-   @"video-highfps": @(PHAssetMediaSubtypeVideoHighFrameRate),
-   @"timelapse": @(PHAssetMediaSubtypeVideoTimelapse),
-   @"portrait": @(PHAssetMediaSubtypePhotoDepthEffect),
-}), PHAssetMediaSubtypeNone, integerValue)
+  @"none": @(PHAssetMediaSubtypeNone),
+  @"panorama": @(PHAssetMediaSubtypePhotoPanorama),
+  @"hdr": @(PHAssetMediaSubtypePhotoHDR),
+  @"screenshot": @(PHAssetMediaSubtypePhotoScreenshot),
+  @"live": @(PHAssetMediaSubtypePhotoLive),
+  @"video-streamed": @(PHAssetMediaSubtypeVideoStreamed),
+  @"video-highfps": @(PHAssetMediaSubtypeVideoHighFrameRate),
+  @"timelapse": @(PHAssetMediaSubtypeVideoTimelapse),
+  @"portrait": @(PHAssetMediaSubtypePhotoDepthEffect),
+                                         }), PHAssetMediaSubtypeNone, integerValue)
 
 @end
 
@@ -63,17 +63,17 @@ RCT_ENUM_CONVERTER(PHAssetMediaSubtype, (@{
 {
   // This is not exhaustive in terms of supported media type predicates; more can be added in the future
   NSString *const lowercase = [mediaType lowercaseString];
-
+  
   NSPredicate * subTypePredicate = nil;
-
+  
   if (subType != PHAssetMediaSubtypeNone) {
     subTypePredicate = [NSPredicate predicateWithFormat:@"(mediaSubtype & %d) != 0", subType];
   }
-
+  
   NSPredicate *mediaTypePredicate = nil;
-
+  
   PHFetchOptions *const options = [PHFetchOptions new];
-
+  
   if ([lowercase isEqualToString:@"photos"]) {
     mediaTypePredicate = [NSPredicate predicateWithFormat:@"mediaType = %d", PHAssetMediaTypeImage];
   } else if ([lowercase isEqualToString:@"videos"]) {
@@ -82,11 +82,11 @@ RCT_ENUM_CONVERTER(PHAssetMediaSubtype, (@{
     if (![lowercase isEqualToString:@"all"]) {
       RCTLogError(@"Invalid filter option: '%@'. Expected one of 'photos',"
                   "'videos' or 'all'.", mediaType);
-
+      
       return options;
     }
   }
-
+  
   if (subTypePredicate != nil && mediaTypePredicate != nil) {
     options.predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[mediaTypePredicate, subTypePredicate]];
   } else if (mediaTypePredicate != nil) {
@@ -94,7 +94,7 @@ RCT_ENUM_CONVERTER(PHAssetMediaSubtype, (@{
   } else if (subTypePredicate != nil) {
     options.predicate = subTypePredicate;
   }
-
+  
   return options;
 }
 
@@ -143,13 +143,13 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
   __block PHFetchResult *photosAsset;
   __block PHAssetCollection *collection;
   __block PHObjectPlaceholder *placeholder;
-
+  
   void (^saveBlock)(void) = ^void() {
     // performChanges and the completionHandler are called on
     // arbitrary threads, not the main thread - this is safe
     // for now since all JS is queued and executed on a single thread.
     // We should reevaluate this if that assumption changes.
-
+    
     [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
       PHAssetChangeRequest *assetRequest ;
       if ([options[@"type"] isEqualToString:@"video"]) {
@@ -174,7 +174,7 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
   };
   void (^saveWithOptions)(void) = ^void() {
     if (![options[@"album"] isEqualToString:@""]) {
-
+      
       PHFetchOptions *fetchOptions = [[PHFetchOptions alloc] init];
       fetchOptions.predicate = [NSPredicate predicateWithFormat:@"title = %@", options[@"album"] ];
       collection = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum
@@ -202,7 +202,7 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
       saveBlock();
     }
   };
-
+  
   void (^loadBlock)(void) = ^void() {
     if ([options[@"type"] isEqualToString:@"video"]) {
       inputURI = request.URL;
@@ -213,13 +213,13 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
           reject(kErrorUnableToLoad, nil, error);
           return;
         }
-
+        
         inputImage = image;
         saveWithOptions();
       }];
     }
   };
-
+  
   requestPhotoLibraryAccess(reject, loadBlock);
 }
 
@@ -231,19 +231,19 @@ static void RCTResolvePromise(RCTPromiseResolveBlock resolve,
     resolve(@{
       @"edges": assets,
       @"page_info": @{
-        @"has_next_page": @NO,
+          @"has_next_page": @NO,
       }
-    });
+            });
     return;
   }
   resolve(@{
     @"edges": assets,
     @"page_info": @{
-      @"start_cursor": assets[0][@"node"][@"image"][@"uri"],
-      @"end_cursor": assets[assets.count - 1][@"node"][@"image"][@"uri"],
-      @"has_next_page": @(hasNextPage),
+        @"start_cursor": assets[0][@"node"][@"image"][@"uri"],
+        @"end_cursor": assets[assets.count - 1][@"node"][@"image"][@"uri"],
+        @"has_next_page": @(hasNextPage),
     }
-  });
+          });
 }
 
 RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
@@ -251,7 +251,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
                   reject:(RCTPromiseRejectBlock)reject)
 {
   checkPhotoLibraryConfig();
-
+  
   NSUInteger const first = [RCTConvert NSInteger:params[@"first"]];
   NSString *const afterCursor = [RCTConvert NSString:params[@"after"]];
   NSString *const groupName = [RCTConvert NSString:params[@"groupName"]];
@@ -259,37 +259,35 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
   NSString *const mediaSubtypeStrings = [[RCTConvert NSString:params[@"mediaSubtypes"]] lowercaseString];
   NSString *const mediaType = [RCTConvert NSString:params[@"assetType"]];
   NSArray<NSString *> *const mimeTypes = [RCTConvert NSStringArray:params[@"mimeTypes"]];
-
+  
   // If groupTypes is "all", we want to fetch the SmartAlbum "all photos". Otherwise, all
   // other groupTypes values require the "album" collection type.
   PHAssetCollectionType const collectionType = ([groupTypes isEqualToString:@"all"]
                                                 ? PHAssetCollectionTypeSmartAlbum
                                                 : PHAssetCollectionTypeAlbum);
   PHAssetCollectionSubtype const collectionSubtype = [RCTConvert PHAssetCollectionSubtype:groupTypes];
-
- PHAssetMediaSubtype const mediaSubtypes = [RCTConvert PHAssetMediaSubtype:mediaSubtypeStrings];
-
+  
+  PHAssetMediaSubtype const mediaSubtypes = [RCTConvert PHAssetMediaSubtype:mediaSubtypeStrings];
+  
   // Predicate for fetching assets within a collection
   PHFetchOptions *const assetFetchOptions = [RCTConvert PHFetchOptionsFromMediaType:mediaType subType:mediaSubtypes];
   assetFetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:NO]];
-
+  
   BOOL __block foundAfter = NO;
   BOOL __block hasNextPage = NO;
   BOOL __block resolvedPromise = NO;
   NSMutableArray<NSDictionary<NSString *, id> *> *assets = [NSMutableArray new];
-
+  
   // Filter collection name ("group")
   PHFetchOptions *const collectionFetchOptions = [PHFetchOptions new];
   collectionFetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"endDate" ascending:NO]];
   if (groupName != nil) {
     collectionFetchOptions.predicate = [NSPredicate predicateWithFormat:[NSString stringWithFormat:@"localizedTitle == '%@'", groupName]];
   }
-
-
-
+  
   BOOL __block stopCollections_;
   NSString __block *currentCollectionName;
-
+  
   requestPhotoLibraryAccess(reject, ^{
     void (^collectAsset)(PHAsset*, NSUInteger, BOOL*) = ^(PHAsset * _Nonnull asset, NSUInteger assetIdx, BOOL * _Nonnull stopAssets) {
       NSString *const uri = [NSString stringWithFormat:@"ph://%@", [asset localIdentifier]];
@@ -299,30 +297,31 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
         }
         return; // skip until we get to the first one
       }
-
-       if (mimeTypes.count > 0) {
-         // Get underlying resources of an asset - this includes files as well as details about edited PHAssets
+      
+      if (mimeTypes.count > 0) {
+        // Get underlying resources of an asset - this includes files as well as details about edited PHAssets
         NSArray<PHAssetResource *> *const assetResources = [PHAssetResource assetResourcesForAsset:asset];
         if (![assetResources firstObject]) {
           return;
         }
         PHAssetResource *const _Nonnull resource = [assetResources firstObject];
-
-       BOOL __block mimeTypeFound = NO;
-       [mimeTypes enumerateObjectsUsingBlock:^(NSString * _Nonnull mimeTypeFilter, NSUInteger idx, BOOL * _Nonnull stop) {
-         if ([mimeType isEqualToString:mimeTypeFilter]) {
-           mimeTypeFound = YES;
-           *stop = YES;
-         }
-       }];
-
-       if (!mimeTypeFound) {
-         return;
-       }
-       
+        
+        NSString *uti = [resource uniformTypeIdentifier];
+        NSString *const mimeType = (NSString *)CFBridgingRelease(UTTypeCopyPreferredTagWithClass((__bridge CFStringRef _Nonnull)(uti), kUTTagClassMIMEType));
+        
+        BOOL __block mimeTypeFound = NO;
+        [mimeTypes enumerateObjectsUsingBlock:^(NSString * _Nonnull mimeTypeFilter, NSUInteger idx, BOOL * _Nonnull stop) {
+          if ([mimeType isEqualToString:mimeTypeFilter]) {
+            mimeTypeFound = YES;
+            *stop = YES;
+          }
+        }];
+        
+        if (!mimeTypeFound) {
+          return;
+        }
       }
-
-
+      
       // If we've accumulated enough results to resolve a single promise
       if (first == assets.count) {
         *stopAssets = YES;
@@ -333,17 +332,17 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
         resolvedPromise = YES;
         return;
       }
-
+      
       NSString *const assetMediaTypeLabel = (asset.mediaType == PHAssetMediaTypeVideo
-                                            ? @"video"
-                                            : (asset.mediaType == PHAssetMediaTypeImage
+                                             ? @"video"
+                                             : (asset.mediaType == PHAssetMediaTypeImage
                                                 ? @"image"
                                                 : (asset.mediaType == PHAssetMediaTypeAudio
-                                                  ? @"audio"
-                                                  : @"unknown")));
+                                                   ? @"audio"
+                                                   : @"unknown")));
       CLLocation *const loc = asset.location;
       NSString *const origFilename = [asset valueForKey:@"filename"];
-
+      
       // A note on isStored: in the previous code that used ALAssets, isStored
       // was always set to YES, probably because iCloud-synced images were never returned (?).
       // To get the "isStored" information and filename, we would need to actually request the
@@ -353,28 +352,28 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
       // Note that Android also does not return the `isStored` field at all.
       [assets addObject:@{
         @"node": @{
-          @"type": assetMediaTypeLabel, // TODO: switch to mimeType?
-          @"group_name": currentCollectionName,
-          @"image": @{
-              @"uri": uri,
-              @"filename": origFilename,
-              @"height": @([asset pixelHeight]),
-              @"width": @([asset pixelWidth]),
-              @"isStored": @YES, // this field doesn't seem to exist on android
-              @"playableDuration": @([asset duration]) // fractional seconds
-          },
-          @"timestamp": @(asset.creationDate.timeIntervalSince1970),
-          @"location": (loc ? @{
+            @"type": assetMediaTypeLabel, // TODO: switch to mimeType?
+            @"group_name": currentCollectionName,
+            @"image": @{
+                @"uri": uri,
+                @"filename": origFilename,
+                @"height": @([asset pixelHeight]),
+                @"width": @([asset pixelWidth]),
+                @"isStored": @YES, // this field doesn't seem to exist on android
+                @"playableDuration": @([asset duration]) // fractional seconds
+            },
+            @"timestamp": @(asset.creationDate.timeIntervalSince1970),
+            @"location": (loc ? @{
               @"latitude": @(loc.coordinate.latitude),
               @"longitude": @(loc.coordinate.longitude),
               @"altitude": @(loc.altitude),
               @"heading": @(loc.course),
               @"speed": @(loc.speed), // speed in m/s
-            } : @{})
-          }
+                                } : @{})
+        }
       }];
     };
-
+    
     if ([groupTypes isEqualToString:@"all"]) {
       PHFetchResult <PHAsset *> *const assetFetchResult = [PHAsset fetchAssetsWithOptions: assetFetchOptions];
       currentCollectionName = @"All Photos";
@@ -389,7 +388,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
         *stopCollections = stopCollections_;
       }];
     }
-
+    
     // If we get this far and haven't resolved the promise yet, we reached the end of the list of photos
     if (!resolvedPromise) {
       hasNextPage = NO;
@@ -409,7 +408,7 @@ RCT_EXPORT_METHOD(deletePhotos:(NSArray<NSString *>*)assets
     [PHAsset fetchAssetsWithALAssetURLs:assets_ options:nil];
     [PHAssetChangeRequest deleteAssets:fetched];
   }
-  completionHandler:^(BOOL success, NSError *error) {
+                                    completionHandler:^(BOOL success, NSError *error) {
     if (success == YES) {
       resolve(@(success));
     }
@@ -417,7 +416,7 @@ RCT_EXPORT_METHOD(deletePhotos:(NSArray<NSString *>*)assets
       reject(@"Couldn't delete", @"Couldn't delete assets", error);
     }
   }
-  ];
+   ];
 }
 
 static void checkPhotoLibraryConfig()

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@react-native-community/cameraroll",
   "author": "Bartol Karuza <bartol.k@gmail.com>",
   "homepage": "https://github.com/react-native-community/react-native-cameraroll#readme",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "React Native Camera Roll for iOS & Android",
   "main": "./js/CameraRoll.js",
   "types": "./typings/CameraRoll.d.ts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@react-native-community/cameraroll",
   "author": "Bartol Karuza <bartol.k@gmail.com>",
   "homepage": "https://github.com/react-native-community/react-native-cameraroll#readme",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "React Native Camera Roll for iOS & Android",
   "main": "./js/CameraRoll.js",
   "types": "./typings/CameraRoll.d.ts",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

We're facing slow performance speed when loading photos. Jared Sumner provided a solution that's explained in more details in #138 and other related issues are #110 and #168 

NOTE: CameraRollExample doesn't work in Xcode 11+ because it requires an upgrade of React Native.

## Test Plan

Since it's an improvement, I ran the existing tests and got no failures.

### What's required for testing (prerequisites)?

1. Run CameraRollExample project
2. Accept access to photo albums
3. Observe the images load speed

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    N/A     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)