### PR TITLE
Added fileSize for getPhotos API

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Returns a Promise which when resolved will be of the following shape:
       * `filename`: {string}
       * `height`: {number}
       * `width`: {number}
+      * `fileSize`: {number}
       * `isStored`: {boolean}
       * `playableDuration`: {number}
     * `timestamp`: {number}

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -77,6 +77,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     Images.Media.DATE_TAKEN,
     MediaStore.MediaColumns.WIDTH,
     MediaStore.MediaColumns.HEIGHT,
+    MediaStore.MediaColumns.SIZE,
     MediaStore.MediaColumns.DATA
   };
 
@@ -456,13 +457,14 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     int dateTakenIndex = media.getColumnIndex(Images.Media.DATE_TAKEN);
     int widthIndex = media.getColumnIndex(MediaStore.MediaColumns.WIDTH);
     int heightIndex = media.getColumnIndex(MediaStore.MediaColumns.HEIGHT);
+    int sizeIndex = media.getColumnIndex(MediaStore.MediaColumns.SIZE);
     int dataIndex = media.getColumnIndex(MediaStore.MediaColumns.DATA);
 
     for (int i = 0; i < limit && !media.isAfterLast(); i++) {
       WritableMap edge = new WritableNativeMap();
       WritableMap node = new WritableNativeMap();
       boolean imageInfoSuccess =
-          putImageInfo(resolver, media, node, idIndex, widthIndex, heightIndex, dataIndex, mimeTypeIndex);
+          putImageInfo(resolver, media, node, idIndex, widthIndex, heightIndex, sizeIndex, dataIndex, mimeTypeIndex);
       if (imageInfoSuccess) {
         putBasicNodeInfo(media, node, mimeTypeIndex, groupNameIndex, dateTakenIndex);
         putLocationInfo(media, node, dataIndex);
@@ -497,6 +499,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       int idIndex,
       int widthIndex,
       int heightIndex,
+      int sizeIndex,
       int dataIndex,
       int mimeTypeIndex) {
     WritableMap image = new WritableNativeMap();
@@ -507,6 +510,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     image.putString("filename", strFileName);
     float width = media.getInt(widthIndex);
     float height = media.getInt(heightIndex);
+    long fileSize = media.getLong(sizeIndex);
 
     String mimeType = media.getString(mimeTypeIndex);
 
@@ -566,6 +570,7 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
     }
     image.putDouble("width", width);
     image.putDouble("height", height);
+    image.putDouble("fileSize", fileSize);
     node.putMap("image", image);
 
     return true;

--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -354,6 +354,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
               @"filename": origFilename,
               @"height": @([asset pixelHeight]),
               @"width": @([asset pixelWidth]),
+              @"fileSize": [resource valueForKey:@"fileSize"],
               @"isStored": @YES, // this field doesn't seem to exist on android
               @"playableDuration": @([asset duration]) // fractional seconds
           },

--- a/js/CameraRoll.js
+++ b/js/CameraRoll.js
@@ -78,6 +78,7 @@ export type PhotoIdentifier = {
       uri: string,
       height: number,
       width: number,
+      fileSize: number,
       isStored?: boolean,
       playableDuration: number,
     },

--- a/typings/CameraRoll.d.ts
+++ b/typings/CameraRoll.d.ts
@@ -39,6 +39,7 @@ declare namespace CameraRoll {
         uri: string,
         height: number,
         width: number,
+        fileSize: number,
         isStored?: boolean,
         playableDuration: number,
       },


### PR DESCRIPTION
Summary

Added fileSize for getPhotos API and changed type returned by iOS implementation to be mimetype to align with the Android implementation.

## Test Plan

### What's required for testing (prerequisites)?
device and emulators for iOS and Android

### What are the steps to reproduce (after prerequisites)?
Run the example package and verified that there is no regression.
Verified that fileSize is included in both iOS and Android looking at output as we console.log the entire data object.
Verified that `type` in iOS now returns the mimetype, same as it is in Android.
Addressed an existed TODO and reach consistency across platforms.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)