### PR TITLE
Use DCIM folder when album is not provided on Android.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,13 @@ The user's permission is required in order to access the Camera Roll on devices 
 If you are targeting devices running iOS 11 or later, you will also need to add the `NSPhotoLibraryAddUsageDescription` key in your `Info.plist`. Use this key to define a string that describes how your app will use this data. By adding this key to your `Info.plist`, you will be able to request write-only access permission from the user. If you try to save to the camera roll without this permission, your app will exit.
 
 On Android permission is required to read the external storage. Add below line to your manifest to request this permission on app install.
+On Android permission is required to write in the external storage when saving to camera roll. Add below line to your manifest to request this permission on app install.
 
 ```
 <manifest>
 ...
 <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 ...
 <application>
 ```
@@ -98,7 +100,8 @@ On iOS, the tag can be any image URI (including local, remote asset-library and 
 
 If the tag has a file extension of .mov or .mp4, it will be inferred as a video. Otherwise it will be treated as a photo. To override the automatic choice, you can pass an optional `type` parameter that must be one of 'photo' or 'video'.
 
-It allows to specify a particular album you want to store the asset to.
+It allows to specify a particular album you want to store the asset to when the param `album` is provided.
+On Android, if no album is provided, DCIM directory is used, otherwise PICTURE or MOVIES directory is used depending on the `type` provided.
 
 Returns a Promise which will resolve with the new URI.
 

--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -129,16 +129,22 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
       File source = new File(mUri.getPath());
       FileChannel input = null, output = null;
       try {
-        File environment;
-        if ("mov".equals(mOptions.getString("type"))) {
-          environment = Environment.getExternalStoragePublicDirectory(
-                  Environment.DIRECTORY_MOVIES);
+        boolean isAlbumPresent = !"".equals(mOptions.getString("album"));
+        
+        final File environment;
+        // Media is not saved into an album when using Environment.DIRECTORY_DCIM.
+        if (isAlbumPresent) {
+          if ("video".equals(mOptions.getString("type"))) {
+            environment = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES);
+          } else {
+            environment = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+          }
         } else {
-          environment = Environment.getExternalStoragePublicDirectory(
-                  Environment.DIRECTORY_PICTURES);
+          environment = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM);
         }
+
         File exportDir;
-        if (!"".equals(mOptions.getString("album"))) {
+        if (isAlbumPresent) {
           exportDir = new File(environment, mOptions.getString("album"));
           if (!exportDir.exists() && !exportDir.mkdirs()) {
             mPromise.reject(ERROR_UNABLE_TO_LOAD, "Album Directory not created. Did you request WRITE_EXTERNAL_STORAGE?");


### PR DESCRIPTION
# Summary

Adjusted README and implemented `save` function to Android to use `DCIM` if no album is provided.

Problem 1:
First of all there is a bug in the current handling of type param for Android in the save function. From doc it's either video or photo, but on implementation https://github.com/react-native-community/react-native-cameraroll/blob/master/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java#L133 it's checking over mov value. If I try to pass mov as value from JS, I got an error on the enum check. So there is no way to reach the current Environment.DIRECTORY_MOVIES dir in Android.

Problem 2:
If I try to simply replace Environment.DIRECTORY_PICTURES with Environment.DIRECTORY_DCIM, the save photo works (no errors) but I never see the new album appearing in the Photos app. I see the new album if I use Environment.DIRECTORY_PICTURES instead.

Problem 3:
Not sure if this is really a problem, but if you save without specifying an album, your media will go into Pictures "album" not into Camera, as opposed if you use DCIM that makes your media appearing to Camera "album/folder". This is a regression compared to the old saveToCameraRoll function.

## Test Plan

### What's required for testing (prerequisites)?
android device/emulator

### What are the steps to reproduce (after prerequisites)?
try to save to camera roll:
1. by providing an album
 a. with video type
 b. with image type
2. by not providing an album

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)