### PR TITLE
Added imageSize and playableDuration to `include` param, deletes isStored

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,7 @@ Returns a Promise which when resolved will be of the following shape:
       * `height`: {number | null} : Only set if the `include` parameter contains `imageSize`
       * `width`: {number | null} : Only set if the `include` parameter contains `imageSize`
       * `fileSize`: {number | null} : Only set if the `include` parameter contains `fileSize`
-      * `isStored`: {boolean}
-      * `playableDuration`: {number | null} : Only set for videos if the `include` parameter contains `playableDuration`
+      * `playableDuration`: {number | null} : Only set for videos if the `include` parameter contains `playableDuration`. Will be null for images.
     * `timestamp`: {number}
     * `location`: {object | null} : Only set if the `include` parameter contains `location`. An object with the following shape:
       * `latitude`: {number}

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ Returns a Promise with photo identifier objects from the local camera roll of th
   * `filename` : Ensures `image.filename` is available in each node. This has a large performance impact on iOS.
   * `fileSize` : Ensures `image.fileSize` is available in each node. This has a large performance impact on iOS.
   * `location`: Ensures `location` is available in each node. This has a large performance impact on Android.
+  * `imageSize` : Ensures `image.width` and `image.height` are available in each node. This has a small performance impact on Android.
+  * `playableDuration` : Ensures `image.playableDuration` is available in each node. This has a medium peformance impact on Android.
 
 Returns a Promise which when resolved will be of the following shape:
 
@@ -181,13 +183,13 @@ Returns a Promise which when resolved will be of the following shape:
     * `group_name`: {string}
     * `image`: {object} : An object with the following shape:
       * `uri`: {string}
-      * `filename`: {string | null} : Only set if the `include` parameter contains `filename`.
-      * `height`: {number}
-      * `width`: {number}
-      * `fileSize`: {number | null} : Only set if the `include` parameter contains `fileSize`.
+      * `filename`: {string | null} : Only set if the `include` parameter contains `filename`
+      * `height`: {number | null} : Only set if the `include` parameter contains `imageSize`
+      * `width`: {number | null} : Only set if the `include` parameter contains `imageSize`
+      * `fileSize`: {number | null} : Only set if the `include` parameter contains `fileSize`
       * `isStored`: {boolean}
-      * `playableDuration`: {number}
-    * `timestamp`: {number} : Timestamp in seconds.
+      * `playableDuration`: {number | null} : Only set for videos if the `include` parameter contains `playableDuration`
+    * `timestamp`: {number}
     * `location`: {object | null} : Only set if the `include` parameter contains `location`. An object with the following shape:
       * `latitude`: {number}
       * `longitude`: {number}

--- a/example/js/GetPhotosPerformanceExample.tsx
+++ b/example/js/GetPhotosPerformanceExample.tsx
@@ -21,14 +21,14 @@ interface State {
    * with `this.first()` before using.
    */
   firstStr: string;
-  /** `after` passed into `getPhotos`. Not passed if empty */
-  after: string;
 }
 
 const includeValues: CameraRoll.Include[] = [
   'filename',
   'fileSize',
   'location',
+  'imageSize',
+  'playableDuration',
 ];
 
 /**
@@ -45,7 +45,6 @@ export default class GetPhotosPerformanceExample extends React.PureComponent<
     output: null,
     include: [],
     firstStr: '1000',
-    after: '',
   };
 
   first = () => {

--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -260,6 +260,8 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
   BOOL __block includeFilename = [include indexOfObject:@"filename"] != NSNotFound;
   BOOL __block includeFileSize = [include indexOfObject:@"fileSize"] != NSNotFound;
   BOOL __block includeLocation = [include indexOfObject:@"location"] != NSNotFound;
+  BOOL __block includeImageSize = [include indexOfObject:@"imageSize"] != NSNotFound;
+  BOOL __block includePlayableDuration = [include indexOfObject:@"playableDuration"] != NSNotFound;
   
   // If groupTypes is "all", we want to fetch the SmartAlbum "all photos". Otherwise, all
   // other groupTypes values require the "album" collection type.
@@ -380,11 +382,13 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
           @"image": @{
               @"uri": uri,
               @"filename": (includeFilename && originalFilename ? originalFilename : [NSNull null]),
-              @"height": @([asset pixelHeight]),
-              @"width": @([asset pixelWidth]),
+              @"height": (includeImageSize ? @([asset pixelHeight]) : [NSNull null]),
+              @"width": (includeImageSize ? @([asset pixelWidth]) : [NSNull null]),
               @"fileSize": (includeFileSize ? fileSize : [NSNull null]),
               @"isStored": @YES, // this field doesn't seem to exist on android
-              @"playableDuration": @([asset duration]) // fractional seconds
+              @"playableDuration": (includePlayableDuration
+                                    ? @([asset duration]) // fractional seconds
+                                    : [NSNull null])
           },
           @"timestamp": @(asset.creationDate.timeIntervalSince1970),
           @"location": (includeLocation && loc ? @{

--- a/ios/RNCCameraRollManager.m
+++ b/ios/RNCCameraRollManager.m
@@ -368,13 +368,6 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
                                                   : @"unknown")));
       CLLocation *const loc = asset.location;
 
-      // A note on isStored: in the previous code that used ALAssets, isStored
-      // was always set to YES, probably because iCloud-synced images were never returned (?).
-      // To get the "isStored" information and filename, we would need to actually request the
-      // image data from the image manager. Those operations could get really expensive and
-      // would definitely utilize the disk too much.
-      // Thus, this field is actually not reliable.
-      // Note that Android also does not return the `isStored` field at all.
       [assets addObject:@{
         @"node": @{
           @"type": assetMediaTypeLabel, // TODO: switch to mimeType?
@@ -385,8 +378,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
               @"height": (includeImageSize ? @([asset pixelHeight]) : [NSNull null]),
               @"width": (includeImageSize ? @([asset pixelWidth]) : [NSNull null]),
               @"fileSize": (includeFileSize ? fileSize : [NSNull null]),
-              @"isStored": @YES, // this field doesn't seem to exist on android
-              @"playableDuration": (includePlayableDuration
+              @"playableDuration": (includePlayableDuration && asset.mediaType != PHAssetMediaTypeImage
                                     ? @([asset duration]) // fractional seconds
                                     : [NSNull null])
           },

--- a/js/CameraRoll.js
+++ b/js/CameraRoll.js
@@ -102,7 +102,6 @@ export type PhotoIdentifier = {
       height: number,
       width: number,
       fileSize: number | null,
-      isStored?: boolean,
       playableDuration: number,
     },
     timestamp: number,

--- a/js/CameraRoll.js
+++ b/js/CameraRoll.js
@@ -31,7 +31,12 @@ const ASSET_TYPE_OPTIONS = {
 
 export type GroupTypes = $Keys<typeof GROUP_TYPES_OPTIONS>;
 
-export type Include = 'filename' | 'fileSize' | 'location';
+export type Include =
+  | 'filename'
+  | 'fileSize'
+  | 'location'
+  | 'imageSize'
+  | 'playableDuration';
 
 /**
  * Shape of the param arg for the `getPhotos` function.

--- a/typings/CameraRoll.d.ts
+++ b/typings/CameraRoll.d.ts
@@ -23,7 +23,11 @@ declare namespace CameraRoll {
     /** Ensures the fileSize is included. Has a large performance hit on iOS */
     | 'fileSize'
     /** Ensures the location is included. Has a medium performance hit on Android */
-    | 'location';
+    | 'location'
+    /** Ensures the image width and height are included. Has a small performance hit on Android */
+    | 'imageSize'
+    /** Ensures the image playableDuration is included. Has a medium performance hit on Android */
+    | 'playableDuration';
 
   /**
    * Shape of the param arg for the `getPhotosFast` function.
@@ -84,6 +88,10 @@ declare namespace CameraRoll {
     include?: Include[];
   }
 
+  type AString = 'a';
+  const a = ['a', 'b', 'c'] as ['a', 'b', 'c'];
+  type ArrayT = ['a', 'b', 'c'];
+
   interface PhotoIdentifier {
     node: {
       type: string;
@@ -92,12 +100,15 @@ declare namespace CameraRoll {
         /** Only set if the `include` parameter contains `filename`. */
         filename: string | null;
         uri: string;
+        /** Only set if the `include` parameter contains `imageSize`. */
         height: number;
+        /** Only set if the `include` parameter contains `imageSize`. */
         width: number;
         /** Only set if the `include` parameter contains `fileSize`. */
         fileSize: number | null;
         isStored?: boolean;
-        playableDuration: number;
+        /** Only set if the `include` parameter contains `playableDuration`. */
+        playableDuration: number | null;
       };
       /** Timestamp in seconds. */
       timestamp: number;

--- a/typings/CameraRoll.d.ts
+++ b/typings/CameraRoll.d.ts
@@ -102,8 +102,10 @@ declare namespace CameraRoll {
         width: number;
         /** Only set if the `include` parameter contains `fileSize`. */
         fileSize: number | null;
-        isStored?: boolean;
-        /** Only set if the `include` parameter contains `playableDuration`. */
+        /**
+         * Only set if the `include` parameter contains `playableDuration`.
+         * Will be null for images.
+         */
         playableDuration: number | null;
       };
       /** Timestamp in seconds. */

--- a/typings/CameraRoll.d.ts
+++ b/typings/CameraRoll.d.ts
@@ -88,10 +88,6 @@ declare namespace CameraRoll {
     include?: Include[];
   }
 
-  type AString = 'a';
-  const a = ['a', 'b', 'c'] as ['a', 'b', 'c'];
-  type ArrayT = ['a', 'b', 'c'];
-
   interface PhotoIdentifier {
     node: {
       type: string;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

**This is another change that is not backwards compatible**

I realized that the Android implementation still had poor performance since it looped through individual images to populate `image.width/height` (some of the time) and `image.playableDuration` (for every video).

Excluding `playableDuration` in particular improves performance significantly when the user has videos.

This change:

- Adds `include` params for `image.width`, `image.height`, and `image.playableDuration`
- Refactors Android code to respect those and avoid looping if the params are excluded
- Makes iOS code respect it too
- Adds documentation

Side change:

- This also deletes the useless `isStored` output that's just a boolean always set to true on iOS

## Test Plan

Added toggles to GetPhotosPerformanceExample.

| iOS | Android |
| --- | --- |
| ![Camera iOS](https://user-images.githubusercontent.com/2937410/84928357-1c496d80-b083-11ea-908e-b8c33f032133.gif) | ![Camera Android](https://user-images.githubusercontent.com/2937410/84928391-2c614d00-b083-11ea-88b0-2e1dfaa66107.gif) |

### What's required for testing (prerequisites)?

Just the standard `yarn start:ios` and `yarn start:android`

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)