### PR TITLE
Fix for error during pod install. Tags have v prefix.

### DIFF
--- a/react-native-cameraroll.podspec
+++ b/react-native-cameraroll.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.platform     = :ios, "9.0"
 
-  s.source       = { :git => "https://github.com/react-native-community/react-native-cameraroll.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/react-native-community/react-native-cameraroll.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'


### PR DESCRIPTION
# Summary

After adding react-native-community/react-native-cameraroll to a project, running pod install fails with an error indicating that tag 2.0.0 cannot be found.

On investigation I found that version tags all have a 'v' prefix. Adding the v prefix in the appropriate place in the podspec fixed the error. This makes react-native-cameraroll consistent with other components in the react-native-community family.

## Test Plan

  * react-native init myproject
  * yarn add @react-native-community/react-native-cameraroll
  * cd ios
  * pod install

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

