### PR TITLE
fix: Revert "Convert PHAsset to JPEG for uploading"

### DIFF
--- a/ios/RNCAssetsLibraryRequestHandler.m
+++ b/ios/RNCAssetsLibraryRequestHandler.m
@@ -118,38 +118,6 @@ RCT_EXPORT_MODULE()
       }
       [delegate URLRequest:cancellationBlock didCompleteWithError:error];
     }];
-  } else if (isPHUpload) {
-    // By default, allow downloading images from iCloud
-    PHImageRequestOptions *const requestOptions = [PHImageRequestOptions new];
-    requestOptions.networkAccessAllowed = YES;
-      requestOptions.deliveryMode = PHImageRequestOptionsDeliveryModeHighQualityFormat;
-
-      CGSize const targetSize = CGSizeMake((CGFloat)asset.pixelWidth, (CGFloat)asset.pixelHeight);
-      [[PHImageManager defaultManager] requestImageForAsset:asset
-                                                 targetSize:targetSize
-                                                contentMode:PHImageContentModeDefault
-                                                    options:requestOptions
-                                              resultHandler:^(UIImage * _Nullable image,
-                                                              NSDictionary * _Nullable info) {
-      NSError *const error = [info objectForKey:PHImageErrorKey];
-      if (error) {
-        [delegate URLRequest:cancellationBlock didCompleteWithError:error];
-        return;
-      }
-      
-      NSData *const imageData = UIImageJPEGRepresentation(image, 1.0);
-      NSInteger const length = [imageData length];
-
-      NSURLResponse *const response = [[NSURLResponse alloc] initWithURL:request.URL
-                                                                MIMEType:@"image/jpeg"
-                                                   expectedContentLength:length
-                                                        textEncodingName:nil];
-
-      [delegate URLRequest:cancellationBlock didReceiveResponse:response];
-
-      [delegate URLRequest:cancellationBlock didReceiveData:imageData];
-      [delegate URLRequest:cancellationBlock didCompleteWithError:nil];
-    }];
   } else {
     // By default, allow downloading images from iCloud
     PHImageRequestOptions *const requestOptions = [PHImageRequestOptions new];


### PR DESCRIPTION
This reverts commit c958493441edf622dbc320b9e1319298b8123481.

fixes #193

BREAKING CHANGE: this reverts forcing all mime types to jpeg on upload, which loses GIF data