### PR TITLE
Remove unnecessary publish job requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,8 @@ workflows:
       #       - analyze
       - publish:
           requires:
-            - rn/android_build
+            - android_debug_build
+            - android_release_build
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ workflows:
       #       - analyze
       - publish:
           requires:
-            - analyze
+            - rn/android_build
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,6 @@ workflows:
       #       - analyze
       - publish:
           requires:
-            - checkout_code
             - analyze
           filters:
             branches:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Cleanup of the CircleCI workflow, there's no need to make publish job dependant of analyze, since analyze is already dependent on checkout_code

<img width="900" alt="Screen Shot 2020-06-30 at 1 21 46 PM" src="https://user-images.githubusercontent.com/10179494/86162589-a73f5480-bad4-11ea-8ba5-b4471c106685.png">

New pipeline:
<img width="896" alt="Screen Shot 2020-06-30 at 1 25 28 PM" src="https://user-images.githubusercontent.com/10179494/86162967-3b112080-bad5-11ea-8417-dab16773ff9c.png">

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)