### PR TITLE
doc: readme usage use recommended `save()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ async function savePicture() {
     return;
   }
 
-  CameraRoll.saveToCameraRoll(tag, [type]);
+  CameraRoll.save(tag, { type, album })
 };
 ```
 


### PR DESCRIPTION
**Motivation**

Add the missed part of change to #183 which deprecate `saveToCameraRoll()` and use the recommended `save()` in README Usage